### PR TITLE
Add `isNull` predicate

### DIFF
--- a/src/JSON.purs
+++ b/src/JSON.purs
@@ -30,7 +30,7 @@ import Data.Function.Uncurried (runFn2, runFn3, runFn7)
 import Data.Int as Int
 import Data.Maybe (Maybe(..))
 import JSON.Internal (JArray, JObject, JSON)
-import JSON.Internal (JArray, JObject, JSON) as Exports
+import JSON.Internal (JArray, JObject, JSON, isNull) as Exports
 import JSON.Internal as Internal
 
 -- | Attempts to parse a string as a JSON value. If parsing fails, an error message detailing the

--- a/src/JSON/Internal.js
+++ b/src/JSON/Internal.js
@@ -57,3 +57,5 @@ export const _index = (nothing, just, ix, arr) =>
   ix >= 0 && ix < arr.length ? just(arr[ix]) : nothing;
 
 export const _append = (xs, ys) => xs.concat(ys);
+
+export const isNull = (json) => json == null;

--- a/src/JSON/Internal.purs
+++ b/src/JSON/Internal.purs
@@ -140,3 +140,5 @@ foreign import _append
        JArray
        JArray
        JArray
+
+foreign import isNull :: JSON -> Boolean

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -35,6 +35,10 @@ main = do
   assertTrue $ J.fromJObject (JO.fromEntries [ Tuple "a" (J.fromInt 1) ]) == J.fromJObject (JO.fromEntries [ Tuple "a" (J.fromInt 1) ])
   assertTrue $ J.fromJObject (JO.fromEntries [ Tuple "a" (J.fromInt 1) ]) < J.fromJObject (JO.fromEntries [ Tuple "a" (J.fromInt 2) ])
 
+  log "Check isNull"
+  assertTrue $ J.isNull J.null
+  assertTrue $ not $ J.isNull (J.fromInt 1)
+
   log "Check array index"
   assertTrue $ JA.index (-1) (JA.fromArray (J.fromInt <$> [ 0, 2, 4 ])) == Nothing
   assertTrue $ JA.index 0 (JA.fromArray (J.fromInt <$> [ 0, 2, 4 ])) == Just (J.fromInt 0)


### PR DESCRIPTION
Allows writing a faster decoder for optional values because you don't have to call `case_` twice to first peel off the null case and then do the actual decoding for the value. This came up [while porting `backend-optimizer`](https://github.com/anttih/purescript-backend-optimizer/commit/2878371ff7ca20b7d344bad7e9e77a85e8286ee5#diff-cab90b0cbfbbfcfa86a7192d01c19377ed47a0f3f5a875c0941fb93abea05d37) to use `json` where I had to add a `nullable`:

```purescript
nullable :: JSON -> Maybe JSON
nullable json = case_
  (const Nothing)
  (Just <<< fromBoolean)
  (Just <<< fromNumber)
  (Just <<< fromString)
  (Just <<< fromJArray)
  (Just <<< fromJObject)
  json
```

I can add predicates for other types as well if needed.

Ping @natefaubion 